### PR TITLE
added `bundle install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ git clone https://github.com/merenlab/web.git
 cd web
 ```
 
+To make sure you have the necesary gems, run:
+
+```
+bundle install
+```
+
 And run the following command in this directory:
 
 ```


### PR DESCRIPTION
So that we avoid the following error:
```bash
$ bundle exec jekyll serve --incremental
Could not find addressable-2.4.0 in any of the sources
Run `bundle install` to install missing gems.
```