### PR TITLE
remove header

### DIFF
--- a/_posts/anvio/2018-01-17-importing-ghostkoala-annotations.md
+++ b/_posts/anvio/2018-01-17-importing-ghostkoala-annotations.md
@@ -171,12 +171,6 @@ Download the annotation file, which will be called `user_ko.txt`, and make sure 
 (...)
 ```
 
-Now run this command on your terminal to add the necessary header line to this file:
-
-```
-echo -e "contig\taccession_id" > .temp && cat user_ko.txt >> .temp && mv .temp user_ko.txt
-```
-
 Now your file is ready to be imported!
 
 For this, we will use the program `KEGG-to-anvio` (which is in the directory you clone from GitHub early on).


### PR DESCRIPTION
@edgraham, I found that this header is not needed, and in fact if I include it then I get an error when trying to import the functions into anvi'o. Do you agree?

If I include this header in `user_ko.txt`, then the **last** line of `KeggAnnotations-AnviImportable.txt` appears as:

```
contig	KeggGhostKoala	accession_id		0
```