### PR TITLE
suggestions for conda install instructions

### DIFF
--- a/_posts/anvio/2016-06-26-installation-v2.md
+++ b/_posts/anvio/2016-06-26-installation-v2.md
@@ -45,12 +45,6 @@ conda update conda
 {:.warning}
 Please make sure you create a new conda enviornment for anvi'o (you can make sure you are not in a conda environment by opening a new terminal and running `conda deactivate`. You can see which environments exist on your coputer by running `conda env list`. You can indeed install anvi'o in an existing conda environment, but if things go wrong, please consider relying on meditation for help rather than [anvi'o community resources]({% post_url anvio/2019-10-07-getting-help %}).
 
-Then, add the following channels that will be required for the anvi'o installation:
-
-``` bash
-conda config --env --add channels conda-forge
-conda config --env --add channels bioconda
-```
 
 Then, create an anvi'o environment for anvi'o v{% include _project-anvio-version-number.html %} (it is essential to create it with Python 3.6 as shown below):
 
@@ -67,7 +61,7 @@ conda activate anvio-6.1
 And finally install anvi'o in it:
 
 ``` bash
-conda install -y anvio=6.1
+conda install -y -c conda-forge -c bioconda anvio=6.1
 ```
 
 This may take a while.


### PR DESCRIPTION
Removing this part: 

>Then, add the following channels that will be required for the anvi'o installation:
>
>``` bash
>conda config --env --add channels conda-forge
>conda config --env --add channels bioconda
>```

Because that changes the user's base conda environment (which i learned myself recently, but makes sense in hindsight), which we don't need to do, as we can just provide the channels in the install command. Listing the channels in the install command (as changed above) will also help with some people apparently missing the first part about setting channels, who are getting stuck at the subsequent "package not found" error (which can then be confusing because another possible cause is listed as a warning at that stage).