### PR TITLE
code typo fixy

### DIFF
--- a/_posts/anvio/2016-06-26-installation-v2.md
+++ b/_posts/anvio/2016-06-26-installation-v2.md
@@ -160,7 +160,7 @@ conda install -y prodigal \
                  mcl \
                  muscle \
                  hmmer \
-                 diamond ==0.9.14 \
+                 diamond==0.9.14 \
                  blast \
                  megahit \
                  bowtie2 \


### PR DESCRIPTION
They need the space before the equals when in environment.yml files, but the space causes an invalid package specification error when doing conda install commands (command-line gonna command) 👍