### PR TITLE
Update 2016-06-26-installation-v2.md

### DIFF
--- a/_posts/anvio/2016-06-26-installation-v2.md
+++ b/_posts/anvio/2016-06-26-installation-v2.md
@@ -214,7 +214,8 @@ Python 3.6.7
 Good? Good. Then, install the following dependencies in this conda environment:
 
 ``` bash
-conda install -y prodigal \
+conda install -y -c conda-forge -c bioconda -c defaults \
+                 prodigal \
                  mcl \
                  muscle \
                  hmmer \


### PR DESCRIPTION
adding needed conda channels to command in linux/windows-users active codebase install codeblock (so will work whether they've been set ahead of time or not on the user's conda)